### PR TITLE
made the installation of mysql community repo's optional for RHEL 7

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'adaptavist-mysqlconfig'
-version 1.0.0'
+version 1.0.1'
 source 'https://github.com/Adaptavist/puppet-mysqlconfig.git'
 author 'adaptavist'
 license 'apache2'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,4 +22,5 @@ class mysqlconfig::params {
     }
     $datadir = false
     $manage_config_file = true
+    $install_community_repo = true
 }


### PR DESCRIPTION
this allows local repo's to be used, also if there is a desire to use mariadb we can disable repo install and manually set mysql_community_server and mysql_community_client package names to mariadb values